### PR TITLE
Drop HSRUN across Ser# read with interrupts off

### DIFF
--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1229,12 +1229,21 @@ void usb_init_serialnumber(void)
 	while (!(FTFL_FSTAT & FTFL_FSTAT_CCIF)) ; // wait
 	num = *(uint32_t *)&FTFL_FCCOB7;
 #elif defined(HAS_KINETIS_FLASH_FTFE)
-	// TODO: does not work in HSRUN mode
+	i=0;	// Track and disable HSRUN mode across ser# read
+	if (SMC_PMSTAT == SMC_PMSTAT_HSRUN) {
+		i=1;
+		SMC_PMCTRL = SMC_PMCTRL_RUNM(0); // exit HSRUN mode
+    		while (SMC_PMSTAT == SMC_PMSTAT_HSRUN) ; // wait for !HSRUN
+	}
 	FTFL_FSTAT = FTFL_FSTAT_RDCOLERR | FTFL_FSTAT_ACCERR | FTFL_FSTAT_FPVIOL;
 	*(uint32_t *)&FTFL_FCCOB3 = 0x41070000;
 	FTFL_FSTAT = FTFL_FSTAT_CCIF;
 	while (!(FTFL_FSTAT & FTFL_FSTAT_CCIF)) ; // wait
 	num = *(uint32_t *)&FTFL_FCCOBB;
+	if ( 1 == i) {
+		SMC_PMCTRL = SMC_PMCTRL_RUNM(3); // enter HSRUN mode
+    		while (SMC_PMSTAT != SMC_PMSTAT_HSRUN) ; // wait for HSRUN
+	}
 #endif
 	__enable_irq();
 	// add extra zero to work around OS-X CDC-ACM driver bug

--- a/teensy3/usb_desc.c
+++ b/teensy3/usb_desc.c
@@ -1229,21 +1229,19 @@ void usb_init_serialnumber(void)
 	while (!(FTFL_FSTAT & FTFL_FSTAT_CCIF)) ; // wait
 	num = *(uint32_t *)&FTFL_FCCOB7;
 #elif defined(HAS_KINETIS_FLASH_FTFE)
-	i=0;	// Track and disable HSRUN mode across ser# read
-	if (SMC_PMSTAT == SMC_PMSTAT_HSRUN) {
-		i=1;
-		SMC_PMCTRL = SMC_PMCTRL_RUNM(0); // exit HSRUN mode
-    		while (SMC_PMSTAT == SMC_PMSTAT_HSRUN) ; // wait for !HSRUN
-	}
+#if F_CPU > 120000000	// Disable HSRUN mode across ser# read
+	SMC_PMCTRL = SMC_PMCTRL_RUNM(0); // exit HSRUN mode
+	while (SMC_PMSTAT == SMC_PMSTAT_HSRUN) ; // wait for !(HSRUN)
+#endif
 	FTFL_FSTAT = FTFL_FSTAT_RDCOLERR | FTFL_FSTAT_ACCERR | FTFL_FSTAT_FPVIOL;
 	*(uint32_t *)&FTFL_FCCOB3 = 0x41070000;
 	FTFL_FSTAT = FTFL_FSTAT_CCIF;
 	while (!(FTFL_FSTAT & FTFL_FSTAT_CCIF)) ; // wait
 	num = *(uint32_t *)&FTFL_FCCOBB;
-	if ( 1 == i) {
-		SMC_PMCTRL = SMC_PMCTRL_RUNM(3); // enter HSRUN mode
-    		while (SMC_PMSTAT != SMC_PMSTAT_HSRUN) ; // wait for HSRUN
-	}
+#if F_CPU > 120000000
+	SMC_PMCTRL = SMC_PMCTRL_RUNM(3); // enter HSRUN mode
+	while (SMC_PMSTAT != SMC_PMSTAT_HSRUN) ; // wait for HSRUN
+#endif
 #endif
 	__enable_irq();
 	// add extra zero to work around OS-X CDC-ACM driver bug


### PR DESCRIPTION
Results in valid serial # presented to USB host when T_3.6 is in HSRUN mode.